### PR TITLE
Fix crash when some programs start

### DIFF
--- a/ANSI.c
+++ b/ANSI.c
@@ -219,6 +219,10 @@
   v1.86, 4 November, 2018:
     always unhook, even on terminate;
     check the DLL still exists before adding to imports.
+
+  v1.87, 3 February, 2019:
+    some hooked functions are not imported, so myimport wasn't set;
+    add missing SetCurrentConsoleFontEx to list of hooks.
 */
 
 #include "ansicon.h"
@@ -2802,6 +2806,10 @@ BOOL HookAPIOneMod(
 	    hook->myimport = &pThunk->u1.Function;
 	    DEBUGSTR( 3, "  %s%s", sp, hook->name );
 	  }
+	  else if (hook->myimport == 0)
+	  {
+	    patch = hook->newfunc;
+	  }
 	  else
 	  {
 	    // Don't hook if our import already points to the module being
@@ -3979,6 +3987,7 @@ HookFn Hooks[] = {
   HOOK( APIConsole,	       SetConsoleScreenBufferSize ),
   HOOK( APIConsole,	       SetConsoleTextAttribute ),
   HOOK( APIConsole,	       SetConsoleWindowInfo ),
+  HOOK( APIConsole,	       SetCurrentConsoleFontEx ),
   HOOK( APIConsole,	       WriteConsoleOutputA ),
   HOOK( APIConsole,	       WriteConsoleOutputW ),
   HOOK( APIConsole,	       WriteConsoleOutputAttribute ),

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2005-2018 Jason Hood
+Copyright (C) 2005-2019 Jason Hood
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the author be held liable for any damages

--- a/ansicon.c
+++ b/ansicon.c
@@ -99,7 +99,7 @@
     add log level 32 to log CreateFile.
 */
 
-#define PDATE L"4 November, 2018"
+#define PDATE L"3 February, 2019"
 
 #include "ansicon.h"
 #include "version.h"

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 
 				    ANSICON
 
-			 Copyright 2005-2018 Jason Hood
+			 Copyright 2005-2019 Jason Hood
 
-			    Version 1.86.  Freeware
+			    Version 1.87.  Freeware
 
 
 Description
@@ -340,6 +340,10 @@ Version History
 
     Legend: + added, - bug-fixed, * changed.
 
+    1.87 - 3 February, 2019:
+    - fix crash when some programs start (bug during hooking);
+    - properly hook SetCurrentConsoleFontEx.
+
     1.86 - 4 November, 2018:
     - check the DLL exists before importing it (allows renaming to update);
     - unhook on terminate, as well (fixes issues with Vista and MinGW).
@@ -641,4 +645,4 @@ Distribution
 
 
 =============================
-Jason Hood, 4 November, 2018.
+Jason Hood, 3 February, 2019.

--- a/version.h
+++ b/version.h
@@ -2,11 +2,11 @@
   version.h - Version defines.
 */
 
-#define PVERS	L"1.86"         // wide string
-#define PVERSA	 "1.86"         // ANSI string (windres 2.16.91 didn't like L)
-#define PVERE	L"186"          // wide environment string
-#define PVEREA	 "186"          // ANSI environment string
-#define PVERB	1,8,6,0 	// binary (resource)
+#define PVERS	L"1.87"         // wide string
+#define PVERSA	 "1.87"         // ANSI string (windres 2.16.91 didn't like L)
+#define PVERE	L"187"          // wide environment string
+#define PVEREA	 "187"          // ANSI environment string
+#define PVERB	1,8,7,0 	// binary (resource)
 
 #ifdef _WIN64
 # define BITS L"64"


### PR DESCRIPTION
A few functions that are hooked are not imported, so testing if my
import was already hooked would fail.

SetCurrentConsoleFontEx should have been hooked, but wasn't.